### PR TITLE
imgprovider.cpp: Make resolution print INFO instead of ERR

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
             },
             "vendorUrl": "https://www.axis.com/",
             "runMode": "respawn",
-            "version": "1.0.2"
+            "version": "1.0.3"
         },
         "configuration": {
             "settingPage": "settings.html",

--- a/src/imgprovider.cpp
+++ b/src/imgprovider.cpp
@@ -162,7 +162,7 @@ bool ImgProvider::ChooseStreamResolution(
     {
         VdoResolution *res = &set->resolutions[i];
         assert(nullptr != res);
-        LOG_E("%s/%s: resolution %zu: (%ux%u)", __FILE__, __FUNCTION__, i, res->width, res->height);
+        LOG_I("%s/%s: resolution %zu: (%ux%u)", __FILE__, __FUNCTION__, i, res->width, res->height);
         if ((res->width >= reqWidth) && (res->height >= reqHeight))
         {
             unsigned int area = res->width * res->height;


### PR DESCRIPTION
### Describe your changes

The resolution print should have been an INFO print from the beginning, not ERR. This patch fixes that.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
