### PR TITLE
Add debug image with marker shown on whole picture

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
             },
             "vendorUrl": "https://www.axis.com/",
             "runMode": "respawn",
-            "version": "1.0.4"
+            "version": "1.0.5"
         },
         "configuration": {
             "settingPage": "settings.html",

--- a/src/colorarea.cpp
+++ b/src/colorarea.cpp
@@ -139,6 +139,18 @@ ColorAreaEllipse::ColorAreaEllipse(
     const uint8_t tolerance)
     : ColorArea(img, point_center, color, markerwidth, markerheight, tolerance)
 {
+#if defined(DEBUG_WRITE)
+    // Create a debug image tho show the marker
+    auto marker_img = img.clone();
+
+    // Draw the ellipse
+    Size axes(markerwidth / 2, markerheight / 2);
+    ellipse(marker_img, point_center, axes, 0, 0, 360, cv::Scalar(0, 0, 0), 3);
+    ellipse(marker_img, point_center, axes, 0, 0, 360, cv::Scalar(255, 255, 255), 1);
+
+    DBG_WRITE_IMG("marker_img.jpg", marker_img);
+#endif
+
     // Create color mask
     colorarea_mask = Mat::zeros(Size(croprange_x.size(), croprange_y.size()), CV_8U);
     ellipse(
@@ -165,6 +177,20 @@ ColorAreaRectangle::ColorAreaRectangle(
     const uint8_t tolerance)
     : ColorArea(img, point_center, color, markerwidth, markerheight, tolerance)
 {
+#if defined(DEBUG_WRITE)
+    // Create a debug image tho show the marker
+    auto marker_img = img.clone();
+
+    // Draw the rectangle
+    auto pt1 = point_center - Point(markerwidth / 2, markerheight / 2);
+    auto pt2 = point_center + Point(markerwidth / 2, markerheight / 2);
+    rectangle(marker_img, pt1, pt2, Scalar(0, 0, 0), 3);
+    rectangle(marker_img, pt1, pt2, Scalar(255, 255, 255), 1);
+
+    DBG_WRITE_IMG("marker_img.jpg", marker_img);
+#endif
+
+    // Create color mask
     colorarea_mask = Mat::ones(Size(croprange_x.size(), croprange_y.size()), CV_8U) * 255;
     DBG_WRITE_IMG("mask_img.jpg", colorarea_mask);
     LOG_I("%s/%s: Rectancular colorarea created", __FILE__, __FUNCTION__);


### PR DESCRIPTION
### Describe your changes

When building & running in debug mode (DEBUG_WRITE=y), sometimes you need to see the marker drawn on the whole picture to get more info on where the crop is done. This patch adds that functionality.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
